### PR TITLE
Update ws.js - remove hardcoded port

### DIFF
--- a/src/services/ws.js
+++ b/src/services/ws.js
@@ -1,4 +1,4 @@
 import io from "socket.io-client";
-const socket = io(":8282/");
+const socket = io("/");
 
 export { socket };


### PR DESCRIPTION
Sometimes we need to run nats-streaming-ui on other ports than 8282.
But there is a hardcoded value in socket client. 
If we will remove hardcoded value than it will connect relatively to origin host which will work for all cases. 
F.e. it will work same for http://localhost:8282 and for http://localhost:8080